### PR TITLE
Corrected jsonserializer.qbs (Android as static library)

### DIFF
--- a/src/jsonserializer/jsonserializer.qbs
+++ b/src/jsonserializer/jsonserializer.qbs
@@ -11,6 +11,8 @@ Project {
         Depends { name: "Qt.core" }
         Depends { name: "cpp" }
 
+        type: (isStaticLibrary ? "staticlibrary" : "dynamiclibrary")
+
         readonly property bool isMacOS: qbs.targetOS.contains("macos")
         readonly property bool isWindows: qbs.targetOS.contains("windows")
         readonly property bool isStaticLibrary: isForAndroid || isMacOS


### PR DESCRIPTION
Library for Android will now be built as static library instead as dynamic one as before.