### PR TITLE
Adjusted to QBS 1.16. Dissolved property "isStaticLibrary" in jsonser…

### DIFF
--- a/src/jsonserializer/jsonserializer.qbs
+++ b/src/jsonserializer/jsonserializer.qbs
@@ -2,6 +2,8 @@ import qbs
 import qbs.TextFile
 
 Project {
+    minimumQbsVersion: "1.16"
+
     property bool install: false
     property string installDir
 
@@ -11,11 +13,9 @@ Project {
         Depends { name: "Qt.core" }
         Depends { name: "cpp" }
 
-        type: (isStaticLibrary ? "staticlibrary" : "dynamiclibrary")
-
         readonly property bool isMacOS: qbs.targetOS.contains("macos")
         readonly property bool isWindows: qbs.targetOS.contains("windows")
-        readonly property bool isStaticLibrary: isForAndroid || isMacOS
+        type: ((isForAndroid || isMacOS) ? "staticlibrary" : "dynamiclibrary")
 
         Group {
             condition: project.install


### PR DESCRIPTION
…ializer.qbs because of name clash with property of same name in QBS's Library.

Please take over the changes. Thank you.